### PR TITLE
Correct supervisor depends cookbook name.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,8 @@ default['lsyncd']['src']['prereqs']['packages'] = [
 default['lsyncd']['bin'] = ::File.join(
   ::File::SEPARATOR, 'usr', 'local', 'bin', 'lsyncd')
 
+default['lsyncd']['options'] = '--nodaemon'
+
 # e.g. /usr/local/bin/lsyncd /etc/lsyncd.conf.lua
 default['lsyncd']['cmd'] = [
-  default['lsyncd']['bin'], default['lsyncd']['conf']].join(' ')
+  default['lsyncd']['bin'], default['lsyncd']['options'], default['lsyncd']['conf']].join(' ')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ default['lsyncd']['src']['dest'] = ::File.join(
   'lsyncd')
 
 default['lsyncd']['src']['prereqs']['packages'] = [
-  'asciidoc', 'autoconf', 'build-essential', 'liblua5.1-0-dev', 'lua5.1']
+  'asciidoc', 'autoconf', 'build-essential', 'liblua5.1-0-dev', 'lua5.1', 'git']
 
 # e.g. /usr/local/bin/lsyncd
 default['lsyncd']['bin'] = ::File.join(

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ description      'Installs/Configures lsyncd.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'
 
-depends 'supervisord'
+depends 'supervisor'


### PR DESCRIPTION
When calling `supervisor_service` the resource will not be found if the
cookbook included is called as `supervisord`. This corrects the depends
to name it correctly. This in turn sees the correct dependency in applications
like librarian and berkshelf.
