### PR TITLE
Tests and packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,56 @@
+---
+driver_plugin: vagrant
+
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    box: vagrant-ubuntu-12.04
+    box_url: http://files.vagrantup.com/precise64.box
+    require_chef_omnibus: true
+  run_list:
+  - recipe[apt]
+- name: ubuntu-10.04
+  driver_config:
+    box: vagrant-ubuntu-10.04
+    box_url: http://files.vagrantup.com/lucid64.box
+    require_chef_omnibus: true
+  run_list:
+  - recipe[apt]
+#- name: centos-6.3
+#  driver_config:
+#    box: opscode-centos-6.3
+#    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.3_chef-11.2.0.box
+#  run_list:
+#  - recipe[yum]
+#- name: centos-5.8
+#  driver_config:
+#    box: opscode-centos-5.8
+#    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.8_chef-11.2.0.box
+#  run_list:
+#  - recipe[yum]
+
+suites:
+- name: lsyncd-default
+  run_list:
+  - recipe[build-essential]
+  - recipe[supervisor]
+  - recipe[lsyncd]
+  attributes: {}
+- name: lsyncd-2.0.7
+  run_list:
+  - recipe[build-essential]
+  - recipe[supervisor]
+  - recipe[lsyncd]
+  attributes:
+    lsyncd:
+      src:
+        revision: "release-2.0.7"
+- name: lsyncd-2.1.4
+  run_list:
+  - recipe[build-essential]
+  - recipe[supervisor]
+  - recipe[lsyncd]
+  attributes:
+    lsyncd:
+      src:
+        revision: "release-2.1.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+script: bundle exec foodcritic .

--- a/Berksfile
+++ b/Berksfile
@@ -4,8 +4,7 @@ metadata
 
 group :integration do
   cookbook 'build-essential'
-  cookbook 'supervisor',
-  :git => 'https://github.com/coderanger/chef-supervisor'
+  cookbook 'supervisor'
   cookbook 'apt'
   cookbook 'yum'
 end

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,11 @@
+site :opscode
+
+metadata
+
+group :integration do
+  cookbook 'build-essential'
+  cookbook 'supervisor',
+  :git => 'https://github.com/coderanger/chef-supervisor'
+  cookbook 'apt'
+  cookbook 'yum'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'
+gem 'test-kitchen', :group => :integration
+gem 'kitchen-vagrant', :group => :integration

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
-gem 'test-kitchen', :group => :integration, ">= 1.0.0.alpha.6"
-gem 'kitchen-vagrant', :group => :integration
+group :integration do
+  gem 'berkshelf'
+  gem 'test-kitchen', ">= 1.0.0.alpha.6"
+  gem 'kitchen-vagrant'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 group :integration do
+  gem 'foodcritic'
   gem 'berkshelf'
   gem 'test-kitchen', ">= 1.0.0.alpha.6"
   gem 'kitchen-vagrant'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf'
-gem 'test-kitchen', :group => :integration
+gem 'test-kitchen', :group => :integration, ">= 1.0.0.alpha.6"
 gem 'kitchen-vagrant', :group => :integration

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Usage
 Add this Recipe to your Run List. You will likely want to add `apt` and
 `build-essential` to the run list, but they are not required.
 
+Testing
+=======
+To test changes, you will need to use [test-kitchen](https://github.com/opscode/test-kitchen) `>= 1.0`. You can use the
+`Gemfile` included to run tests, but the gems can be installed globally.
+A couple of prereqs that need to be installed as packages are [Vagrant](http://www.vagrantup.com/)
+and [Virtualbox](https://www.virtualbox.org/)
+
+    $ vagrant plugin install vagrant-berkshelf
+    $ bundle install
+    $ bundle exec kitchen test
+
 License
 =======
 Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Attributes
 * `['lsyncd']['src']['prereqs']['packages']`: Prerequisite packages for
   building lsyncd.
 * `['lsyncd']['bin']`: Destination path for lsyncd binary.
+* `['lsyncd']['options']`: Extra options to pass to lsyncd through supervisord.
 * `['lsyncd']['cmd']`: Command arguments to pass to supervisord.
 
 Usage
 =====
-Add this Recipe to your Run List.
+Add this Recipe to your Run List. You will likely want to add `apt` and
+`build-essential` to the run list, but they are not required.
 
 License
 =======

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,82 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  config.vm.hostname = "cookbook-lsyncd-berkshelf"
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "Berkshelf-CentOS-6.3-x86_64-minimal"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "https://dl.dropbox.com/u/31081437/Berkshelf-CentOS-6.3-x86_64-minimal.box"
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  config.vm.network :private_network, ip: "33.33.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+
+  # config.vm.network :public_network
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  config.ssh.max_tries = 40
+  config.ssh.timeout   = 120
+
+  # The path to the Berksfile to use with Vagrant Berkshelf
+  # config.berkshelf.berksfile_path = "./Berksfile"
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to exclusively install and copy to Vagrant's shelf.
+  # config.berkshelf.only = []
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to skip installing and copying to Vagrant's shelf.
+  # config.berkshelf.except = []
+
+  config.vm.provision :chef_solo do |chef|
+    chef.json = {
+      :mysql => {
+        :server_root_password => 'rootpass',
+        :server_debian_password => 'debpass',
+        :server_repl_password => 'replpass'
+      }
+    }
+
+    chef.run_list = [
+      "recipe[cookbook-lsyncd::default]"
+    ]
+  end
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,8 @@ default['lsyncd']['src']['prereqs']['packages'] = [
 default['lsyncd']['bin'] = ::File.join(
   ::File::SEPARATOR, 'usr', 'local', 'bin', 'lsyncd')
 
+default['lsyncd']['options'] = '--nodaemon'
+
 # e.g. /usr/local/bin/lsyncd /etc/lsyncd.conf.lua
 default['lsyncd']['cmd'] = [
-  default['lsyncd']['bin'], default['lsyncd']['conf']].join(' ')
+  default['lsyncd']['bin'], default['lsyncd']['options'], default['lsyncd']['conf']].join(' ')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,16 @@ default['lsyncd']['src']['dest'] = ::File.join(
   'lsyncd')
 
 default['lsyncd']['src']['prereqs']['packages'] = [
-  'asciidoc', 'autoconf', 'build-essential', 'liblua5.1-0-dev', 'lua5.1', 'git']
+  'xsltproc',
+  'autoconf',
+  'build-essential',
+  'docbook',
+  'docbook-xsl',
+  'liblua5.1-0-dev',
+  'lua5.1',
+  'libtool',
+  'libxml2-utils',
+  'git-core']
 
 # e.g. /usr/local/bin/lsyncd
 default['lsyncd']['bin'] = ::File.join(

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ default['lsyncd']['src']['dest'] = ::File.join(
   'lsyncd')
 
 default['lsyncd']['src']['prereqs']['packages'] = [
-  'asciidoc', 'autoconf', 'build-essential', 'liblua5.1-0-dev', 'lua5.1']
+  'asciidoc', 'autoconf', 'build-essential', 'liblua5.1-0-dev', 'lua5.1', 'git']
 
 # e.g. /usr/local/bin/lsyncd
 default['lsyncd']['bin'] = ::File.join(

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             'lsyncd'
 maintainer       'Greg Albrecht'
 maintainer_email 'gba@gregalbrecht.com'
 license          'Apache License 2.0'
@@ -6,3 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.1.0'
 
 depends 'supervisor'
+supports 'ubuntu', '>= 10.04'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ description      'Installs/Configures lsyncd.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'
 
-depends 'supervisord'
+depends 'supervisor'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'gba@gregalbrecht.com'
 license          'Apache License 2.0'
 description      'Installs/Configures lsyncd.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 
 depends 'supervisor'
 supports 'ubuntu', '>= 10.04'

--- a/recipes/build.rb
+++ b/recipes/build.rb
@@ -24,7 +24,7 @@ execute 'lsyncd src autogen' do
   action :nothing
   command './autogen.sh'
   cwd node['lsyncd']['src']['dest']
-  subscribes(:run, resources(:git => 'lsyncd src sync'))
+  subscribes :run, "git[lsyncd src sync]"
 end
 
 
@@ -32,7 +32,7 @@ execute 'lsyncd src configure' do
   action :nothing
   command './configure'
   cwd node['lsyncd']['src']['dest']
-  subscribes(:run, resources(:execute => 'lsyncd src autogen'))
+  subscribes :run, "execute[lsyncd src autogen]"
 end
 
 
@@ -40,5 +40,5 @@ execute 'lsyncd src make' do
   action :nothing
   command 'make'
   cwd node['lsyncd']['src']['dest']
-  subscribes(:run, resources(:execute => 'lsyncd src configure'))
+  subscribes :run, "execute[lsyncd src configure]"
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -13,5 +13,5 @@ execute 'lsyncd src make install' do
   action :nothing
   command 'make install'
   cwd node['lsyncd']['src']['dest']
-  subscribes(:run, resources(:execute => 'lsyncd src make'))
+  subscribes :run, "execute[lsyncd src make]"
 end

--- a/recipes/prereq.rb
+++ b/recipes/prereq.rb
@@ -8,7 +8,10 @@
 # License:: Apache License 2.0
 #
 
+package 'asciidoc' do
+  options '--no-install-recommends'
+end
 
 node['lsyncd']['src']['prereqs']['packages'].each do |pkg|
-  package(pkg).run_action(:install)
+  package pkg
 end

--- a/recipes/run.rb
+++ b/recipes/run.rb
@@ -10,7 +10,9 @@
 
 
 supervisor_service 'lsyncd' do
-  action [:enable, :start]
+  action :enable
+  autostart true
+  autorestart true
   only_if{ ::File.exists?(node['lsyncd']['bin']) }
   command node['lsyncd']['cmd']
   process_name 'lsyncd'


### PR DESCRIPTION
This update will install the minimal packages needed to compile `lsyncd`. The problem with installing `asciidoc` and allowing the recommended packages to be installed, is the size of all the downloads adding up to ~500M. This takes time just to download all packages, and extends the initial run up to 30 minutes or more.

This new minimal package install is less than 3 minutes with dependencies.

I have also added initial framework for the new `test-kitchen` that is releasing soon. I've already ensured all converge test suites pass with supported Ubuntu releases.
